### PR TITLE
Remove 'pricing rules' from "Control" section

### DIFF
--- a/index.md
+++ b/index.md
@@ -48,7 +48,7 @@ permalink: /
       <i class="fas fa-clipboard-list"></i>
       Plans, Rules & Limits
     </h1>
-    <p><span class="conditional-highlight">Control</span> access to your APIs with plans, metrics, methods and rate limits.</p>
+    <p><span class="conditional-highlight">Control</span> access to your APIs with plans, metrics, methods, and rate limits.</p>
   </section>
   <section class="functional">
     <ol class="feature-chain">


### PR DESCRIPTION
Remove 'pricing rules' from "Control" section as they are not for control and they are also part of "monetize" section